### PR TITLE
Fix missing 'literal' method error while renaming class

### DIFF
--- a/lib/App/PRT/Command/RenameClass.pm
+++ b/lib/App/PRT/Command/RenameClass.pm
@@ -158,7 +158,10 @@ sub _try_rename_parent_class {
         my $parent = $statement->schild(2);
 
         if ($parent->isa('PPI::Token::Quote')) {
-            if ($parent->literal eq $self->source_class_name) {
+            # The 'literal' method is not implemented by ::Quote::Double or ::Quote::Interpolate.
+            my $string = $parent->can('literal') ? $parent->literal : $parent->string;
+
+            if ($string eq $self->source_class_name) {
                 $parent->set_content("'@{[ $self->destination_class_name ]}'");
                 $replaced++;
             }

--- a/t/App-PRT-Command-RenameClass.t
+++ b/t/App-PRT-Command-RenameClass.t
@@ -138,6 +138,18 @@ package Child3 {
     use base 'Boss';
 };
 
+package Child4 {
+    use base 'Boss';
+};
+
+package Child5 {
+    use base 'Boss';
+};
+
+package Child6 {
+    use base 'Boss';
+};
+
 package GrandChild {
     use base 'Child';
 };

--- a/t/data/inherit/inherit.pl
+++ b/t/data/inherit/inherit.pl
@@ -12,6 +12,18 @@ package Child3 {
     use base 'Parent';
 };
 
+package Child4 {
+    use base "Parent";
+};
+
+package Child5 {
+    use base q{Parent};
+};
+
+package Child6 {
+    use base qq/Parent/;
+};
+
 package GrandChild {
     use base 'Child';
 };


### PR DESCRIPTION
This fixes _"Can't locate object method "literal" via package "PPI::Token::Quote::Double""_ error while renaming class name in `use base "..."` (and `use base qq{...}`).

``` perl
package Child {
    use base "Parent";
}
```

The `literal` method of PPI::Token::Quote is not implemented by ::Quote::Double or ::Quote::Interpolate ([POD](http://search.cpan.org/%7Eadamk/PPI-1.215/lib/PPI/Token/Quote.pm#literal)). So I use the `string` method if the `literal` method is missing.
