### PR TITLE
Support function to rename symbols on RenameClass command

### DIFF
--- a/t/App-PRT-Command-RenameClass.t
+++ b/t/App-PRT-Command-RenameClass.t
@@ -44,6 +44,8 @@ sub execute : Tests {
 package My::Meal;
 use strict;
 use warnings;
+$My::Meal::VERSION = '0.01';
+$My::Food::Foo::GLOBAL_VAR = 'foobar';
 
 sub new {
     my ($class, $name) = @_;
@@ -78,6 +80,9 @@ use lib 'lib';
 
 use My::Human;
 use My::Meal;
+
+undef *My::Meal::new;
+undef *My::Food::Foo::new;
 
 my $human = My::Human->new('Alice');
 my $food = My::Meal->new('Pizza');

--- a/t/App-PRT-Command-RenameNameSpace.t
+++ b/t/App-PRT-Command-RenameNameSpace.t
@@ -98,6 +98,9 @@ use lib 'lib';
 use Our::Human;
 use Our::Food;
 
+undef *Our::Food::new;
+undef *My::Food::Foo::new;
+
 my $human = Our::Human->new('Alice');
 my $food = Our::Food->new('Pizza');
 
@@ -113,6 +116,8 @@ CODE
 package Our::Food;
 use strict;
 use warnings;
+$Our::Food::VERSION = '0.01';
+$My::Food::Foo::GLOBAL_VAR = 'foobar';
 
 sub new {
     my ($class, $name) = @_;

--- a/t/App-PRT-Command-ReplaceToken.t
+++ b/t/App-PRT-Command-ReplaceToken.t
@@ -87,6 +87,9 @@ use lib 'lib';
 use My::Human;
 use My::Food;
 
+undef *My::Food::new;
+undef *My::Food::Foo::new;
+
 my $human = My::Human->new('Alice');
 my $food = My::Food->new->bake('Pizza');
 
@@ -105,6 +108,8 @@ CODE
 package My::Food;
 use strict;
 use warnings;
+$My::Food::VERSION = '0.01';
+$My::Food::Foo::GLOBAL_VAR = 'foobar';
 
 sub new {
     my ($klass, $name) = @_;
@@ -140,6 +145,9 @@ use lib 'lib';
 use My::Human;
 use My::Food;
 
+undef *My::Food::new;
+undef *My::Food::Foo::new;
+
 my $human = NewHuman('Alice');
 my $food = My::Food->new('Pizza');
 
@@ -162,6 +170,9 @@ use lib 'lib';
 
 use My::Human;
 use My::Food;
+
+undef *My::Food::new;
+undef *My::Food::Foo::new;
 
 my $human = My::Human->new('Alice');
 my $food = My::Food->new->bake('Pizza');

--- a/t/data/dinner/dinner.pl
+++ b/t/data/dinner/dinner.pl
@@ -5,6 +5,9 @@ use lib 'lib';
 use My::Human;
 use My::Food;
 
+undef *My::Food::new;
+undef *My::Food::Foo::new;
+
 my $human = My::Human->new('Alice');
 my $food = My::Food->new('Pizza');
 

--- a/t/data/dinner/lib/My/Food.pm
+++ b/t/data/dinner/lib/My/Food.pm
@@ -1,6 +1,8 @@
 package My::Food;
 use strict;
 use warnings;
+$My::Food::VERSION = '0.01';
+$My::Food::Foo::GLOBAL_VAR = 'foobar';
 
 sub new {
     my ($class, $name) = @_;


### PR DESCRIPTION
Now `rename_class` method doesn't support to replace symbols (e.g. global var, type glob, and etc), so implemented it.
How do you feel?
## SYNOPSIS

```
$Foo::Bar::GLOBAL_VAR
 ~~~~~~~~ Rename here

$Foo::Bar::Buz::GLOBAL_VAR # <= Don't rename
           ~~~ cuz here name space exists, so both are different
```
