### PR TITLE
rename_class: Rename package files starting with comments or POD

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root=true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'perl', '5.010001';
 requires 'Class::Load';
 requires 'Getopt::Long', '2.42';
-requires 'PPI';
+requires 'PPI', '0.844';    # for schild bugfix
 requires 'Path::Class';
 requires 'File::Find::Rule';
 requires 'File::Temp';

--- a/lib/App/PRT.pm
+++ b/lib/App/PRT.pm
@@ -29,13 +29,25 @@ App::PRT - Command line Perl Refactoring Tool
 
 App::PRT is command line tools for Refactoring Perl.
 
+=head1 CONTRIBUTING
+
+App::PRT uses L<Minilla> for development.  The tests assume C<.> is in the
+Perl library path.  On Perl 5.26+, before running C<minil test>, add C<.>
+to the path.  For example, in C<bash>:
+
+    export PERL5LIB="$PERL5LIB":.
+
+Each command in the L<prt> tool is implemented by a corresponding class
+under C<App::PRT::Command>.  For example, C<rename_class> is implemented
+by L<App::PRT::Command::RenameClass>.
+
 =head1 SEE ALSO
 
-L<prt>
+L<prt> for command-line usage.
 
 =head1 LICENSE
 
-Copyright (C) hitode909.
+Copyright (C) 2014-2019 hitode909 and contributors.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/lib/App/PRT/Command/RenameClass.pm
+++ b/lib/App/PRT/Command/RenameClass.pm
@@ -105,8 +105,9 @@ sub _try_rename_package_statement {
 
     $namespace->set_content($self->destination_class_name);
 
-    # rename this file when the first token is package (heuristic)
-    return $document->find_first('PPI::Token') eq 'package';
+    # Rename this file when the first significant token is package (heuristic).
+    # This skips comments and POD before the package statement.
+    return $document->schild(0)->DOES('PPI::Statement::Package');
 }
 
 sub _try_rename_includes {

--- a/script/prt
+++ b/script/prt
@@ -88,7 +88,7 @@ When executed in git repository, All files in the repository are used.
 
 =head1 LICENSE
 
-Copyright (C) hitode909.
+Copyright (C) 2014-2019 hitode909 and contributors.
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/t/App-PRT-Command-RenameClass.t
+++ b/t/App-PRT-Command-RenameClass.t
@@ -33,7 +33,7 @@ sub execute : Tests {
 
         is $command->execute($food_file), $meal_file, 'returns destination file when success';
 
-        ok ! -f $food_file, "Food.pm doesn't exists";
+        ok ! -f $food_file, "Food.pm doesn't exist";
         ok -e $meal_file, "Meal.pm exists";
 
         is file($meal_file)->slurp, <<'CODE', 'package statement was rewritten';
@@ -89,6 +89,66 @@ CODE
      };
 }
 
+sub execute_package_with_comment_first : Tests {
+    my $directory = t::test::prepare_test_code('tokens_before_package');
+
+    my $command = App::PRT::Command::RenameClass->new;
+
+    $command->register('My::Commented' => 'My::Commented2');
+
+    my $file_in = "$directory/lib/My/Commented.pm";
+    my $file_out = "$directory/lib/My/Commented2.pm";
+
+    is $command->execute($file_in), $file_out, 'returns destination file when success';
+
+    ok ! -f $file_in, "$file_in doesn't exist";
+    ok -e $file_out, "$file_out exists";
+
+    is file($file_out)->slurp, <<'CODE', 'package statement was rewritten';
+# A package with a comment before the `package` statement
+package My::Commented2;
+use strict;
+use warnings;
+
+sub new { bless {}, shift; }
+
+1;
+CODE
+
+}
+
+sub execute_package_with_pod_first : Tests {
+    my $directory = t::test::prepare_test_code('tokens_before_package');
+
+    my $command = App::PRT::Command::RenameClass->new;
+
+    $command->register('My::POD' => 'My::POD2');
+
+    my $file_in = "$directory/lib/My/POD.pm";
+    my $file_out = "$directory/lib/My/POD2.pm";
+
+    is $command->execute($file_in), $file_out, 'returns destination file when success';
+
+    ok ! -f $file_in, "$file_in doesn't exist";
+    ok -e $file_out, "$file_out exists";
+
+    is file($file_out)->slurp, <<'CODE', 'package statement was rewritten';
+=head1 NAME
+
+My::POD - A package with POD before the `package` statement
+
+=cut
+
+package My::POD2;
+use strict;
+use warnings;
+
+sub new { bless {}, shift; }
+
+1;
+CODE
+
+}
 sub execute_with_inherit : Tests {
     my $directory = t::test::prepare_test_code('inherit');
 
@@ -176,7 +236,7 @@ sub execute_test_class_style_test_file: Tests {
     $command1->register('t::My::Food' => 't::My::Meal');
     $command1->execute($food_file);
 
-    ok ! -f $food_file, "Food._t doesn't exists";
+    ok ! -f $food_file, "Food._t doesn't exist";
     ok -e $meal_file, "Meal._t exists";
 
     is file($meal_file)->slurp, <<'CODE', 'package statement replaced';
@@ -225,7 +285,7 @@ sub execute_rename_to_deeper_directory : Tests {
 
         is $command->execute($food_file), $special_food_file, 'success';
 
-        ok ! -f $food_file, "Food.pm doesn't exists";
+        ok ! -f $food_file, "Food.pm doesn't exist";
         ok -e $special_food_file, "Special::Great::Food.pm exists";
     };
 }

--- a/t/data/tokens_before_package/lib/My/Commented.pm
+++ b/t/data/tokens_before_package/lib/My/Commented.pm
@@ -1,0 +1,8 @@
+# A package with a comment before the `package` statement
+package My::Commented;
+use strict;
+use warnings;
+
+sub new { bless {}, shift; }
+
+1;

--- a/t/data/tokens_before_package/lib/My/POD.pm
+++ b/t/data/tokens_before_package/lib/My/POD.pm
@@ -1,0 +1,13 @@
+=head1 NAME
+
+My::POD - A package with POD before the `package` statement
+
+=cut
+
+package My::POD;
+use strict;
+use warnings;
+
+sub new { bless {}, shift; }
+
+1;


### PR DESCRIPTION
Currently, `prt rename_class` will not rename the class file unless the `package 'Foo';` statement is the first thing in the file.  This PR changes that so that the `package` statement can be preceded by comments or POD.

I also added a [`.editorconfig` file](https://editorconfig.org) to automatically configure editors that support it for the project's style (as best I can tell).

Thank you for considering this PR!