### PR TITLE
Add options to show help from the prt script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /App-PRT-*
 /.build
+/_build
 /_build_params
 /Build
 /Build.bat
@@ -7,3 +8,6 @@
 !META.json
 !LICENSE
 .perl-version
+/blib/
+/cover_db/
+*.tmp

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension App-PRT
 
 {{$NEXT}}
+    - Add options to show help from the prt script: -h, -?, --help (#39)
 
 0.22 2019-05-29T02:56:11Z
     - Add list_files command

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hitode909/App-PRT.svg?branch=master)](https://travis-ci.org/hitode909/App-PRT) [![Coverage Status](https://img.shields.io/coveralls/hitode909/App-PRT/master.svg?style=flat)](https://coveralls.io/r/hitode909/App-PRT?branch=master)
+[![Build Status](https://travis-ci.org/cxw42/App-PRT.svg?branch=master)](https://travis-ci.org/cxw42/App-PRT) [![Coverage Status](https://img.shields.io/coveralls/cxw42/App-PRT/master.svg?style=flat)](https://coveralls.io/r/cxw42/App-PRT?branch=master)
 # NAME
 
 App::PRT - Command line Perl Refactoring Tool

--- a/cpanfile
+++ b/cpanfile
@@ -1,11 +1,14 @@
 requires 'perl', '5.010001';
 requires 'Class::Load';
-requires 'Getopt::Long', '2.42';
-requires 'PPI', '0.844';    # for schild bugfix
-requires 'Path::Class';
+requires 'Cwd';
 requires 'File::Find::Rule';
 requires 'File::Temp';
+requires 'Getopt::Long', '2.34';        # for auto_help
 requires 'IO::Interactive';
+requires 'List::MoreUtils', '0.401';    # for most recent API
+requires 'Path::Class';
+requires 'Pod::Usage';
+requires 'PPI', '0.844';    # for schild bugfix
 
 on configure => sub {
     requires 'CPAN::Meta';
@@ -20,10 +23,17 @@ on 'test' => sub {
     requires 'Test::Deep';
     requires 'Test::Mock::Guard';
     requires 'Path::Class';
+    requires 'File::Basename';
     requires 'File::Copy::Recursive';
+    requires 'File::pushd';
+    requires 'File::Spec::Functions';
+    requires 'File::Temp';
+    requires 'FindBin';
     requires 'parent';
     requires 'Capture::Tiny', '0.39';
     requires 'File::pushd', '1.013';
+    requires 'lib';
+    requires 'List::Util', '1.43';
 };
 
 on develop => sub {

--- a/script/prt
+++ b/script/prt
@@ -1,8 +1,11 @@
 #!perl
-
+use 5.010001;
 use strict;
 use warnings;
+use App::PRT;
 use App::PRT::CLI;
+
+our $VERSION = $App::PRT::VERSION;  # for Getopt::Long auto_version
 
 my $cli = App::PRT::CLI->new;
 $cli->set_io(*STDIN, *STDOUT);
@@ -21,11 +24,13 @@ prt - Command line frontend of App::PRT
     $ prt <command> <args>
     $ prt <command> <args> <files>
 
+Run C<prt --man> for full help.
+
 =head1 DESCRIPTION
 
 prt is the command line frontend of L<App::PRT>.
 
-=head1 SUBCOMMANDS
+=head1 COMMANDS
 
 =over 4
 
@@ -100,6 +105,26 @@ C<App::PRT> looks for a C<cpanfile> to detect the project's root directory.
 When executed in a git repository, all files in the repository are used.
 
     prt replace_token foo bar   # Refactor the project in current working directory
+
+=head1 OTHER OPTIONS
+
+These can be specified before the C<< <command> >>:
+
+=over
+
+=item B<-h>, B<--help>, B<-?>
+
+Show brief help
+
+=item B<--man>
+
+Show full help (this page)
+
+=item B<--version>
+
+Show the version of C<prt>
+
+=back
 
 =head1 LICENSE
 

--- a/t/test.pm
+++ b/t/test.pm
@@ -5,7 +5,9 @@ use warnings;
 use utf8;
 
 use Path::Class;
-use lib file(__FILE__)->dir->parent->subdir('lib')->stringify;
+
+# Make all @INC absolute since we will be changing directories
+BEGIN { $_ = Path::Class::Dir->new($_)->absolute->stringify foreach @INC; }
 
 use FindBin;
 use File::Spec::Functions qw/catfile/;


### PR DESCRIPTION
(**Edited description**) 

Closes #39:
- App::PRT::CLI:
  - Use Getopt::Long to process -h, -?, --help, --man, and --version
  - Call exit() (via Getopt::Long::HelpMessage) rather than die() on invalid calls.
- t/App-PRT-CLI.t:
  - Use Capture::Tiny and system() to test, since Getopt::Long calls exit().  See https://stackoverflow.com/q/56856646/2877364 .
  - When testing `--man` output, permit ANSI boldface or double-striking.
  - Instead of mocking Cwd::getcwd(), actually change dir using File::pushd.  The mock was not being released properly on my system when running under Devel::Cover, which caused later tests to fail.
- cpanfile: Add some dependencies that were not expressly listed
- General: reorder module lists into alphabetical order so it is easier to see what is used

Closes #41: 
- t/test.pm: Make all `@inc` absolute