### PR TITLE
Canonicalize the tempdir

### DIFF
--- a/t/test.pm
+++ b/t/test.pm
@@ -9,6 +9,7 @@ use Path::Class;
 # Make all @INC absolute since we will be changing directories
 BEGIN { $_ = Path::Class::Dir->new($_)->absolute->stringify foreach @INC; }
 
+use Cwd ();
 use FindBin;
 use File::Spec::Functions qw/catfile/;
 use File::Temp qw(tempdir);
@@ -54,7 +55,7 @@ sub prepare_test_code {
     my ($name) = @_;
 
     my $base_directory = catfile($FindBin::Bin, 'data', $name);
-    my $tmpdir = tempdir;
+    my $tmpdir = Cwd::abs_path(tempdir);
 
     unless (-d $base_directory) {
         die "$name is not defined";


### PR DESCRIPTION
1. In OSX, tempdir returns a directory under /var/..., and it is symlink of /private/var/...
- https://apple.stackexchange.com/questions/22694/private-tmp-vs-private-var-tmp-vs-tmpdir

```
t/App-PRT-CLI.t ......................... 1/?
    #   Failed test 'parse'
    #   at /Users/hitode909/.plenv/versions/5.28.0/lib/perl5/5.28.0/Test/Builder.pm line 158.
    #   (in t::App::PRT::CLI->parse)
    # Compared (Part 2 of 2 in $data)->directory
    #    got : '/private/var/folders/y_/m950yrnj2jq9t5zv89d10kv40000gn/T/jz0hqgjuQy'
    # expect : '/var/folders/y_/m950yrnj2jq9t5zv89d10kv40000gn/T/jz0hqgjuQy'
    # Looks like you failed 1 test of 2.
```

2. File::pushd canonicalizes $target_dir
- https://metacpan.org/source/DAGOLDEN/File-pushd-1.016/lib/File/pushd.pm#L50